### PR TITLE
Removes serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "^3.4.1",
-    "serialize-javascript": ">=2.1.1"
+    "react-scripts": "^3.4.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
**This PR**
Removes `serialize-javascript`

**Why?**
It isn't needed (explicitly at least). I think I added to try and fix an audit issue or something but I don't see any changes to `npm audit` with or without it.